### PR TITLE
Remove jfrDir configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ mvn -Pnative clean verify
 ```
 Native image builds may use more than 4G of RAM to complete.
 
-### Run the server, targeting a jfr file
+### Run the server
 
 If you built a JAR:
 ```
@@ -34,12 +34,6 @@ java -jar ./server/target/server-1.0.0-SNAPSHOT-runner.jar
 If you built a native image:
 ```
 ./server/target/server-1.0.0-SNAPSHOT-runner
-```
-
-By default, the server will load files from the directory `file-upload`. To change this, set the System Property `jfrDir`. For example:
-```
-java -DjfrDir="/some/path" ./server/target/server-1.0.0-SNAPSHOT-runner.jar
-./server/target/server-1.0.0-SNAPSHOT-runner -DjfrDir="/some/path"
 ```
 
 ### Run Grafana

--- a/server/src/main/java/com/redhat/jfr/server/JfrResource.java
+++ b/server/src/main/java/com/redhat/jfr/server/JfrResource.java
@@ -4,12 +4,10 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Set;
 
-import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
 import com.redhat.jfr.events.RecordingService;
 
-import io.quarkus.runtime.StartupEvent;
 import io.quarkus.vertx.web.Route;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.JsonObject;
@@ -20,19 +18,11 @@ import io.vertx.ext.web.RoutingContext;
 
 public class JfrResource {
     private static final Logger LOGGER = LoggerFactory.getLogger(RecordingService.class);
-    private static final String JFR_PROPERTY = "jfrDir";
-    private String jfrDir = "file-uploads";
+
+    private static final String jfrDir = "file-uploads";
 
     @Inject
     RecordingService service;
-
-    void onStart(@Observes StartupEvent event) {
-        String dir = System.getProperty(JFR_PROPERTY);
-        if (dir != null && dir != "") {
-            jfrDir = dir;
-        }
-        LOGGER.info("Set JFR Directory to: " + jfrDir);
-    }
 
     @Route(path = "/")
     void root(RoutingContext context) {
@@ -77,8 +67,7 @@ public class JfrResource {
         HttpServerResponse response = context.response();
         setHeaders(response);
 
-        String filename = (jfrDir != null || jfrDir != "") ? jfrDir + File.separator + context.getBodyAsString()
-                : context.getBodyAsString();
+        String filename = jfrDir + File.separator + context.getBodyAsString();
 
         try {
             service.loadEvents(filename);


### PR DESCRIPTION
This removes the jfrDir configuration in favour of a static directory 'file-uploads'. In the future configuration can be added back, but in a fully functional state rather than a partially functional state.