### PR TITLE
Update base image for s2i builder

### DIFF
--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/quarkus/centos-quarkus-native-s2i:latest
+FROM quay.io/quarkus/ubi-quarkus-native-s2i:19.2.1
 
 USER root
 


### PR DESCRIPTION
`centos-quarkus-native-s2i` is replaced by `ubi-quarkus-native-s2i` which has a newer version of graalvm, needed for the updated plugins used by the project.