### PR TITLE
Make listen host configurable, bump Quarkus version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,8 +23,8 @@
 
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.4.2.Final</quarkus.platform.version>
-    <quarkus-plugin.version>1.4.2.Final</quarkus-plugin.version>
+    <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
+    <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
   </properties>
 
   <dependencyManagement>

--- a/src/main/docker/Dockerfile.native
+++ b/src/main/docker/Dockerfile.native
@@ -3,4 +3,5 @@ WORKDIR /work/
 COPY target/*-runner /work/application
 RUN chmod 775 /work
 EXPOSE 8080
-CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]
+ENV LISTEN_HOST=${LISTEN_HOST:-0.0.0.0}
+CMD ["./application", "-Dquarkus.http.host=${LISTEN_HOST}"]


### PR DESCRIPTION
This will allow us to optionally listen for only connections from containers in the same pod by setting LISTEN_HOST to 127.0.0.1. I have also updated to a more recent version of Quarkus.