### PR TITLE
Check for vulnerable deps, misc cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This project depends on JMC Core libraries which are acquired from the sonatype 
 https://github.com/openjdk/jmc7
 ```
 
-For native image support, graalvm 20.3.0 is needed with path to it's directory set via environment variable `GRAALVM_HOME`. This can be downloaded from:
+For native image support, graalvm 20.3.0 (Java 11 version) is needed with path to it's directory set via environment variable `GRAALVM_HOME`. This can be downloaded from:
 ```
 https://github.com/graalvm/graalvm-ce-builds/releases
 ```
@@ -30,7 +30,7 @@ https://podman.io/getting-started/installation.html
 
 ### Build and run locally
 
-This project uses [Quarkus](https://quarkus.io), which can produce a JAR to run in a JVM, or an executable native image.
+This project uses [Quarkus](https://quarkus.io), which can produce a JAR to run in a JVM (JDK 11+), or an executable native image.
 
 To build a JAR:
 ```

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ This demonstrates how a simple json data source can be used in Grafana to read t
 
 This project depends on JMC Core libraries which are acquired from the sonatype repositories. They can also be built from the 'core' maven project at:
 ```
-http://hg.openjdk.java.net/jmc/jmc
+https://github.com/openjdk/jmc7
 ```
 
-For native image support, graalvm 19.3.2 or 20.1.0 is needed with path to it's directory set via environment variable `GRAALVM_HOME`. This can be downloaded from:
+For native image support, graalvm 20.3.0 is needed with path to it's directory set via environment variable `GRAALVM_HOME`. This can be downloaded from:
 ```
 https://github.com/graalvm/graalvm-ce-builds/releases
 ```
@@ -51,11 +51,11 @@ To build a native image within a container, for a consistent environment:
 
 If you built a JAR:
 ```
-java -jar ./server/target/server-1.0.0-SNAPSHOT-runner.jar
+java -jar ./target/jfr-datasource-2.0.0-SNAPSHOT-runner.jar
 ```
 If you built a native image:
 ```
-./server/target/server-1.0.0-SNAPSHOT-runner
+./target/jfr-datasource-2.0.0-SNAPSHOT-runner
 ```
 
 ### Run Grafana

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <junit.version>5.5.1</junit.version>
     <rest-assured.version>3.0.0</rest-assured.version>
 
-    <jmc.core.version>7.0.0-SNAPSHOT</jmc.core.version>
+    <jmc.core.version>7.1.0-SNAPSHOT</jmc.core.version>
 
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <maven-surefire-plugin.version>2.22.1</maven-surefire-plugin.version>
     <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
 
-    <java.version>1.8</java.version>
+    <java.version>11</java.version>
     <junit.version>5.5.1</junit.version>
     <rest-assured.version>3.0.0</rest-assured.version>
 
@@ -179,8 +179,7 @@
           <fork>true</fork>
           <meminitial>128m</meminitial>
           <maxmem>1024m</maxmem>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
+          <release>${java.version}</release>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -3,8 +3,8 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.redhat.jfr.datasource</groupId>
   <artifactId>jfr-datasource</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
-  <name>JFR Prototype Datasource</name>
+  <version>2.0.0-SNAPSHOT</version>
+  <name>JFR Datasource</name>
 
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -16,15 +16,16 @@
 
     <java.version>1.8</java.version>
     <junit.version>5.5.1</junit.version>
-    <vertx.version>3.7.0</vertx.version>
     <rest-assured.version>3.0.0</rest-assured.version>
 
     <jmc.core.version>7.0.0-SNAPSHOT</jmc.core.version>
 
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
-    <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
+    <quarkus.platform.version>1.11.0.Final</quarkus.platform.version>
+    <quarkus-plugin.version>1.11.0.Final</quarkus-plugin.version>
+
+    <org.owasp.dependency.check.version>6.0.5</org.owasp.dependency.check.version>
   </properties>
 
   <dependencyManagement>
@@ -136,6 +137,33 @@
             <configuration>
               <trimStackTrace>false</trimStackTrace>
             </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>dep-check</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.owasp</groupId>
+            <artifactId>dependency-check-maven</artifactId>
+            <version>${org.owasp.dependency.check.version}</version>
+            <configuration>
+              <failBuildOnAnyVulnerability>true</failBuildOnAnyVulnerability>
+              <suppressionFiles>
+                <suppressionFile>releng/dep-check-suppressions.xml</suppressionFile>
+              </suppressionFiles>
+            </configuration>
+            <executions>
+              <execution>
+                <id>check-for-vulnerable-deps</id>
+                <goals>
+                  <goal>check</goal>
+                </goals>
+                <phase>validate</phase>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>

--- a/releng/dep-check-suppressions.xml
+++ b/releng/dep-check-suppressions.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress>
+        <notes><![CDATA[
+        Suppresses false positives for io.smallrye.reactive/mutiny and related projects
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.smallrye\.reactive/.*mutiny.*@.*$</packageUrl>
+        <cpe>cpe:/a:mutiny:mutiny</cpe>
+    </suppress>
+</suppressions>


### PR DESCRIPTION
This PR adds a profile to check for vulnerable dependencies using OWASP Dependency Check. There's a suppression file added for false positives related to smallrye-mutiny. This also upgrades Quarkus to pull in a newer vertx which fixes CVE-2019-17640, and JMC to 7.1.0-SNAPSHOT to closer align with what's used for Container JFR.

I also bumped the version to 2.0.0 (will backport to v1 branch) and fixed up the README a bit.