### PR TITLE
Use Quarkus versions defined in BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,18 +54,15 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-vertx-web</artifactId>
-      <version>${quarkus.platform.version}</version>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-jaxb</artifactId>
-      <version>${quarkus.platform.version}</version>
     </dependency>
 
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5</artifactId>
-      <version>${quarkus.platform.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
The versions for the Quarkus dependencies we use are already defined within the quarkus-bom we import. This eliminates the redundant version tags in our POM. This also helps with downstream builds.