### PR TITLE
[v1] Use Quarkus versions defined in BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,18 +54,15 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-vertx-web</artifactId>
-      <version>${quarkus.platform.version}</version>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-jaxb</artifactId>
-      <version>${quarkus.platform.version}</version>
     </dependency>
 
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5</artifactId>
-      <version>${quarkus.platform.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Direct backport of #57. No conflicts.