### PR TITLE
Update to Quarkus 1.11.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ Native image builds may use more than 4G of RAM to complete.
 
 To build a native image within a container, for a consistent environment:
 ```
- mvn -Pnative -Dquarkus.native.container-runtime=podman verify
+ mvn -Pnative -Dquarkus.native.container-build=true -Dquarkus.native.container-runtime=podman \
+    -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel:20.3.1.2-Final-java11 \
+    clean verify
 ```
 
 #### Run the server

--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,8 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                    <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                    <maven.home>${maven.home}</maven.home>
                   </systemProperties>
                 </configuration>
               </execution>
@@ -186,6 +188,7 @@
         <configuration>
           <systemProperties>
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+            <maven.home>${maven.home}</maven.home>
           </systemProperties>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -22,11 +22,16 @@
 
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.11.0.Final</quarkus.platform.version>
-    <quarkus-plugin.version>1.11.0.Final</quarkus-plugin.version>
+    <quarkus.platform.version>1.11.6.Final</quarkus.platform.version>
+    <quarkus-plugin.version>1.11.6.Final</quarkus-plugin.version>
 
     <org.owasp.dependency.check.version>6.0.5</org.owasp.dependency.check.version>
     <build-helper-maven-plugin.version>3.2.0</build-helper-maven-plugin.version>
+
+    <quarkus.native.enable-http-url-handler>true</quarkus.native.enable-http-url-handler>
+    <quarkus.native.additional-build-args>
+      -H:ReflectionConfigurationResources=reflection.json
+    </quarkus.native.additional-build-args>
   </properties>
 
   <dependencyManagement>
@@ -90,31 +95,11 @@
   <profiles>
     <profile>
       <id>native</id>
-      <activation>
-        <property>
-          <name>native</name>
-        </property>
-      </activation>
+      <properties>
+        <quarkus.package.type>native</quarkus.package.type>
+      </properties>
       <build>
         <plugins>
-          <plugin>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-maven-plugin</artifactId>
-            <version>${quarkus-plugin.version}</version>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>native-image</goal>
-                </goals>
-                <configuration>
-                  <enableHttpUrlHandler>true</enableHttpUrlHandler>
-                  <additionalBuildArgs>
-                    -H:ReflectionConfigurationFiles=reflection.json
-                  </additionalBuildArgs>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
@@ -184,10 +169,13 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
         <version>${quarkus-plugin.version}</version>
+        <extensions>true</extensions>
         <executions>
           <execution>
             <goals>
               <goal>build</goal>
+              <goal>generate-code</goal>
+              <goal>generate-code-tests</goal>
             </goals>
           </execution>
         </executions>

--- a/src/main/java/com/redhat/jfr/server/JfrResource.java
+++ b/src/main/java/com/redhat/jfr/server/JfrResource.java
@@ -10,6 +10,8 @@ import java.util.UUID;
 
 import javax.inject.Inject;
 
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
 import com.redhat.jfr.events.RecordingService;
 
 import io.quarkus.vertx.web.Route;
@@ -22,8 +24,9 @@ import io.vertx.ext.web.RoutingContext;
 
 public class JfrResource {
   private static final Logger LOGGER = LoggerFactory.getLogger(RecordingService.class);
-
-  private static final String jfrDir = "file-uploads";
+  
+  @ConfigProperty(name = "quarkus.http.body.uploads-directory")
+  String jfrDir;
 
   @Inject
   RecordingService service;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+quarkus.http.body.uploads-directory=${java.io.tmpdir}${file.separator}jfr-file-uploads

--- a/src/test/java/com/redhat/jfr/tests/DatasourceTest.java
+++ b/src/test/java/com/redhat/jfr/tests/DatasourceTest.java
@@ -8,9 +8,8 @@ import java.io.File;
 import java.nio.file.Files;
 
 import org.eclipse.microprofile.config.ConfigProvider;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.junit.QuarkusTest;
@@ -18,12 +17,9 @@ import io.quarkus.test.junit.QuarkusTest;
 @QuarkusTest
 public class DatasourceTest {
 
-  @ConfigProperty(name = "quarkus.http.body.uploads-directory")
-  String jfrDir;
-
   @AfterEach
   public void afterEachDatasourceTest() {
-    File directory = new File(jfrDir);
+    File directory = new File(System.getProperty("java.io.tmpdir"), "jfr-file-uploads");
     if (directory.exists() && directory.isDirectory()) {
       for (File f : directory.listFiles()) {
         if (f.isFile()) {

--- a/src/test/java/com/redhat/jfr/tests/DatasourceTest.java
+++ b/src/test/java/com/redhat/jfr/tests/DatasourceTest.java
@@ -7,6 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.File;
 import java.nio.file.Files;
 
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -16,9 +18,12 @@ import io.quarkus.test.junit.QuarkusTest;
 @QuarkusTest
 public class DatasourceTest {
 
+  @ConfigProperty(name = "quarkus.http.body.uploads-directory")
+  String jfrDir;
+
   @AfterEach
   public void afterEachDatasourceTest() {
-    File directory = new File("file-uploads");
+    File directory = new File(jfrDir);
     if (directory.exists() && directory.isDirectory()) {
       for (File f : directory.listFiles()) {
         if (f.isFile()) {


### PR DESCRIPTION
This PR updates Quarkus, and changes the build to match the current recommendations:
https://quarkus.io/version/1.11/guides/maven-tooling

Additionally, the uploads directory is read from Quarkus's configuration, instead of relying on the default location. This is useful as the default directory is changing in 1.12:
https://github.com/quarkusio/quarkus/wiki/Migration-Guide-1.12#http

I also updated the README native-image build instructions to be more reproducible. An image for testing is available at `quay.io/ebaron/jfr-datasource:1.0.0-BETA6`.