### PR TITLE
chore(deps): downgrade redhat-actions/buildah-build action to v2

### DIFF
--- a/.github/workflows/push-ci.yaml
+++ b/.github/workflows/push-ci.yaml
@@ -47,7 +47,7 @@ jobs:
       run: mvn -B -U clean verify
     - name: Build container images and manifest
       id: buildah-build
-      uses: redhat-actions/buildah-build@54ff9945b9f9320e460006b5ea63dfac279906b0 # v2.2.2
+      uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2
       env:
         IMAGE_VERSION: ${{ needs.get-pom-properties.outputs.image-version }}
       with:


### PR DESCRIPTION
This reverts commit 72032751a2a96c9e2996ee9d613a8a6c1607119a (#530).
